### PR TITLE
Int128 division implementation

### DIFF
--- a/velox/type/Decimal.h
+++ b/velox/type/Decimal.h
@@ -93,16 +93,18 @@ struct Int128 {
    *
    * @return Int128 quotient.
    */
-  static Int128 Division(Int128 lhs, Int128 rhs, Int128& remainder) {
+  static Int128 divisionMod(Int128 lhs, Int128 rhs, Int128& remainder) {
     VELOX_CHECK_NE(rhs.value, 0, "Divide by zero error");
     remainder = 0;
-    bool isNegative = false;
+    bool isLhsNegative = false;
     if (lhs.value < 0) {
-      isNegative = true;
+      isLhsNegative = true;
       lhs = lhs.complement();
     }
+
+    bool isRhsNegative = false;
     if (rhs.value < 0) {
-      isNegative = !isNegative;
+      isRhsNegative = true;
       rhs = rhs.complement();
     }
 
@@ -119,12 +121,15 @@ struct Int128 {
         quotient = quotient + 1;
       }
     }
-    return isNegative ? quotient.complement() : quotient;
+
+    remainder = (isLhsNegative) ? remainder.complement() : remainder;
+
+    return (isLhsNegative ^ isRhsNegative) ? quotient.complement() : quotient;
   }
 
   Int128 operator/(Int128& rhs) {
     Int128 remainder;
-    return Division(*this, rhs, remainder);
+    return divisionMod(*this, rhs, remainder);
   }
 
   bool operator>=(const Int128& rhs) {
@@ -320,7 +325,9 @@ static const Int128 POWERS_OF_TEN[] = {
     Int128(100000000000000000) * Int128(100000000000000000) * Int128(10),
     Int128(100000000000000000) * Int128(100000000000000000) * Int128(100),
     Int128(100000000000000000) * Int128(100000000000000000) * Int128(1000),
-    Int128(100000000000000000) * Int128(100000000000000000) * Int128(10000)};
+    Int128(100000000000000000) * Int128(100000000000000000) *
+        Int128(10000)}; // 10^38
+
 class DecimalCasts {
  public:
   static Decimal parseStringToDecimal(const std::string& value) {

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -364,60 +364,61 @@ TEST(type, leftMostBitSet128) {
   EXPECT_EQ(Int128::leftMostBitSet(Int128(0x0000000000000001)), 0);
 }
 
-TEST(type, int128Division) {
+TEST(type, int128divisionMod) {
   Int128 dividend(1023);
   Int128 divisor(31);
   Int128 remainder(0);
-  EXPECT_EQ(Int128::Division(dividend, divisor, remainder), 33);
+  EXPECT_EQ(Int128::divisionMod(dividend, divisor, remainder), 33);
   EXPECT_EQ(remainder, 0);
 
   dividend = 1030;
-  EXPECT_EQ(Int128::Division(dividend, divisor, remainder), 33);
+  EXPECT_EQ(Int128::divisionMod(dividend, divisor, remainder), 33);
   EXPECT_EQ(remainder, 7);
 
   dividend = -1030;
-  EXPECT_EQ(Int128::Division(dividend, divisor, remainder), -33);
-  EXPECT_EQ(remainder, 7);
+  EXPECT_EQ(Int128::divisionMod(dividend, divisor, remainder), -33);
+  EXPECT_EQ(remainder, -7);
 
   dividend = 1030;
   divisor = -31;
-  EXPECT_EQ(Int128::Division(dividend, divisor, remainder), -33);
+  EXPECT_EQ(Int128::divisionMod(dividend, divisor, remainder), -33);
   EXPECT_EQ(remainder, 7);
 
   dividend = 20;
   divisor = 10000;
-  EXPECT_EQ(Int128::Division(dividend, divisor, remainder), 0);
+  EXPECT_EQ(Int128::divisionMod(dividend, divisor, remainder), 0);
   EXPECT_EQ(remainder, 20);
 
   dividend = -204678;
   divisor = -31;
-  EXPECT_EQ(Int128::Division(dividend, divisor, remainder), 6602);
-  EXPECT_EQ(remainder, 16);
+  EXPECT_EQ(Int128::divisionMod(dividend, divisor, remainder), 6602);
+  EXPECT_EQ(remainder, -16);
 
-  EXPECT_THROW(Int128::Division(dividend, 0, remainder), VeloxRuntimeError);
+  EXPECT_THROW(Int128::divisionMod(dividend, 0, remainder), VeloxRuntimeError);
   dividend = POWERS_OF_TEN[38];
   divisor = POWERS_OF_TEN[14];
   // 10000000000000000000000
-  EXPECT_EQ(Int128::Division(dividend, divisor, remainder), POWERS_OF_TEN[24]);
+  EXPECT_EQ(
+      Int128::divisionMod(dividend, divisor, remainder), POWERS_OF_TEN[24]);
   EXPECT_EQ(remainder, 0);
 
   dividend = Int128(1234567890123456) * POWERS_OF_TEN[10];
   divisor = Int128(123456) * POWERS_OF_TEN[12];
-  EXPECT_EQ(Int128::Division(dividend, divisor, remainder), 100000639);
+  EXPECT_EQ(Int128::divisionMod(dividend, divisor, remainder), 100000639);
   EXPECT_EQ(remainder, Int128(1285056) * POWERS_OF_TEN[10]);
 
   dividend = Int128::min();
   divisor = 2;
   EXPECT_EQ(
-      Int128::Division(dividend, divisor, remainder),
+      Int128::divisionMod(dividend, divisor, remainder),
       Int128(MERGE_INT128(0xC000000000000000, 0)));
   EXPECT_EQ(remainder, 0);
 
   dividend = Int128::max();
   divisor = 2;
-  Int128 quotient = Int128::Division(dividend, divisor, remainder);
+  Int128 quotient = Int128::divisionMod(dividend, divisor, remainder);
   EXPECT_EQ(
-      Int128::Division(dividend, divisor, remainder),
+      Int128::divisionMod(dividend, divisor, remainder),
       Int128(MERGE_INT128(0x3FFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF)));
   EXPECT_EQ(remainder, 1);
 }

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -350,6 +350,78 @@ TEST(Type, Int128RightShiftOperator) {
       testHexVal >> 64);
 }
 
+TEST(type, leftMostBitSet128) {
+  Int128 testHexVal(0x0000000000000001);
+
+  EXPECT_EQ(
+      Int128::leftMostBitSet(Int128(MERGE_INT128(0x8000000000000000, 0))), 127);
+  EXPECT_EQ(
+      Int128::leftMostBitSet(Int128(MERGE_INT128(0x7000000000000000, 0))), 126);
+  EXPECT_EQ(
+      Int128::leftMostBitSet(Int128(MERGE_INT128(0x1, 0x7000000000000000))),
+      64);
+  EXPECT_EQ(Int128::leftMostBitSet(Int128(0xF000000000000001)), 63);
+  EXPECT_EQ(Int128::leftMostBitSet(Int128(0x0000000000000001)), 0);
+}
+
+TEST(type, int128Division) {
+  Int128 dividend(1023);
+  Int128 divisor(31);
+  Int128 remainder(0);
+  EXPECT_EQ(Int128::Division(dividend, divisor, remainder), 33);
+  EXPECT_EQ(remainder, 0);
+
+  dividend = 1030;
+  EXPECT_EQ(Int128::Division(dividend, divisor, remainder), 33);
+  EXPECT_EQ(remainder, 7);
+
+  dividend = -1030;
+  EXPECT_EQ(Int128::Division(dividend, divisor, remainder), -33);
+  EXPECT_EQ(remainder, 7);
+
+  dividend = 1030;
+  divisor = -31;
+  EXPECT_EQ(Int128::Division(dividend, divisor, remainder), -33);
+  EXPECT_EQ(remainder, 7);
+
+  dividend = 20;
+  divisor = 10000;
+  EXPECT_EQ(Int128::Division(dividend, divisor, remainder), 0);
+  EXPECT_EQ(remainder, 20);
+
+  dividend = -204678;
+  divisor = -31;
+  EXPECT_EQ(Int128::Division(dividend, divisor, remainder), 6602);
+  EXPECT_EQ(remainder, 16);
+
+  EXPECT_THROW(Int128::Division(dividend, 0, remainder), VeloxRuntimeError);
+  dividend = POWERS_OF_TEN[38];
+  divisor = POWERS_OF_TEN[14];
+  // 10000000000000000000000
+  EXPECT_EQ(Int128::Division(dividend, divisor, remainder), POWERS_OF_TEN[24]);
+  EXPECT_EQ(remainder, 0);
+
+  dividend = Int128(1234567890123456) * POWERS_OF_TEN[10];
+  divisor = Int128(123456) * POWERS_OF_TEN[12];
+  EXPECT_EQ(Int128::Division(dividend, divisor, remainder), 100000639);
+  EXPECT_EQ(remainder, Int128(1285056) * POWERS_OF_TEN[10]);
+
+  dividend = Int128::min();
+  divisor = 2;
+  EXPECT_EQ(
+      Int128::Division(dividend, divisor, remainder),
+      Int128(MERGE_INT128(0xC000000000000000, 0)));
+  EXPECT_EQ(remainder, 0);
+
+  dividend = Int128::max();
+  divisor = 2;
+  Int128 quotient = Int128::Division(dividend, divisor, remainder);
+  EXPECT_EQ(
+      Int128::Division(dividend, divisor, remainder),
+      Int128(MERGE_INT128(0x3FFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF)));
+  EXPECT_EQ(remainder, 1);
+}
+
 TEST(Type, Map) {
   auto map0 = MAP(INTEGER(), ARRAY(BIGINT()));
   EXPECT_EQ(map0->toString(), "MAP<INTEGER,ARRAY<BIGINT>>");


### PR DESCRIPTION
Arithmetic division operator implementation. This implementation is similar to
duckdb HugeInt division operation. Refer:
https://github.com/duckdb/duckdb/blob/master/src/common/types/hugeint.cpp#L257.

The algorithm is defined in Knuth's Art of Programming Vol2 chapter 4.3.1. This
implementaion is similar to performing division with paper and pen. Here is an
example:

```
lhs  1023
rhs  31

Split into 64-bit integers:

UPPER(int64) |    LOWER(uint64)
-------------------------------------
lhs  0         |  1023
rhs  0         |  31

        0000100001   <--- QUOTIENT = 33
       -------------------
11111 | 1111111111
      - 11111
       -------------
        000001
             11
             111
             1111
             11111
           - 11111
          --------------
             00000  <--- Remainder = 0
```

Testing:
Added unit tests.