### PR TITLE
Add support for literal parameters in SignatureBinder

### DIFF
--- a/velox/expression/SignatureBinder.h
+++ b/velox/expression/SignatureBinder.h
@@ -57,5 +57,10 @@ class SignatureBinder {
   const exec::FunctionSignature& signature_;
   const std::vector<TypePtr>& actualTypes_;
   std::unordered_map<std::string, TypePtr> bindings_;
+  bool checkTypesWithLiterals(
+      const TypeSignature& parameterSignature,
+      const TypePtr& baseType,
+      const int pos);
+  static TypePtr resolveDecimalType(const TypeSignature& signature);
 };
 } // namespace facebook::velox::exec

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -43,6 +43,17 @@ TEST(SignatureBinderTest, generics) {
     testSignatureBinder(signature, {ARRAY(BIGINT()), BIGINT()}, BOOLEAN());
   }
 
+  {
+    // Test binding a signature that accepts Types parameters that are long
+    // literals.
+    auto signature = exec::FunctionSignatureBuilder()
+                         .returnType("DECIMAL(10,5)")
+                         .argumentType("DECIMAL(10,5)")
+                         .argumentType("DECIMAL(10,5)")
+                         .build();
+    testSignatureBinder(
+        signature, {DECIMAL(10, 5), DECIMAL(10, 5)}, DECIMAL(10, 5));
+  }
   // array(array(T)), array(T) -> boolean
   {
     auto signature = exec::FunctionSignatureBuilder()

--- a/velox/functions/prestosql/ArrayIntersectExcept.cpp
+++ b/velox/functions/prestosql/ArrayIntersectExcept.cpp
@@ -455,10 +455,10 @@ std::shared_ptr<exec::VectorFunction> createArrayExcept(
 std::vector<std::shared_ptr<exec::FunctionSignature>> signatures(
     const std::string& returnType) {
   return {exec::FunctionSignatureBuilder()
-              .typeVariable("T")
+              .typeVariable("T") // Decimal
               .returnType(returnType)
-              .argumentType("array(T)")
-              .argumentType("array(T)")
+              .argumentType("array(T)") // decimal(p1,s1)
+              .argumentType("array(T)") // decimal(p2, s2)
               .build()};
 }
 

--- a/velox/functions/prestosql/DecimalArithmetic.cpp
+++ b/velox/functions/prestosql/DecimalArithmetic.cpp
@@ -1,0 +1,5 @@
+//
+// Created by Karteek Murthy Samba Murthy on 4/7/22.
+//
+
+#include "DecimalArithmetic.h"

--- a/velox/functions/prestosql/DecimalArithmetic.h
+++ b/velox/functions/prestosql/DecimalArithmetic.h
@@ -1,0 +1,10 @@
+//
+// Created by Karteek Murthy Samba Murthy on 4/7/22.
+//
+
+#ifndef VELOX_DECIMALARITHMETIC_H
+#define VELOX_DECIMALARITHMETIC_H
+
+class DecimalArithmetic {};
+
+#endif // VELOX_DECIMALARITHMETIC_H

--- a/velox/type/Decimal.h
+++ b/velox/type/Decimal.h
@@ -48,7 +48,7 @@ struct Int128 {
     this->value = rhs.value;
   }
 
-  Int128 operator+(Int128& rhs) {
+  Int128 operator+(const Int128& rhs) const {
     Int128 sum;
     VELOX_CHECK(!__builtin_add_overflow(this->value, rhs.value, &sum.value));
     return sum;
@@ -98,6 +98,12 @@ class Decimal {
     unscaledValue_ = value;
   }
 
+  inline Decimal operator+(const Decimal& rhs) const {
+    // Test implementation;
+    // Verify if these 2 decimals can be added together.
+    Int128 result = this->unscaledValue_ + rhs.getUnscaledValue();
+    return Decimal(result);
+  }
   // Needed for serialization of FlatVector<Decimal>
   operator StringView() const {VELOX_NYI()}
 

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -362,9 +362,16 @@ bool Type::kindEquals(const std::shared_ptr<const Type>& other) const {
   if (this->size() != other->size()) {
     return false;
   }
-  for (size_t i = 0; i < this->size(); ++i) {
-    if (!this->childAt(i)->kindEquals(other->childAt(i))) {
+  if (this->kind() == TypeKind::DECIMAL) {
+    // special case, the children are parameters and not Types.
+    if(dynamic_cast<const DecimalType*>(this)->typmod() !=
+        dynamic_cast<const DecimalType*>(other.get())->typmod())
       return false;
+  } else {
+    for (size_t i = 0; i < this->size(); ++i) {
+      if (!this->childAt(i)->kindEquals(other->childAt(i))) {
+        return false;
+      }
     }
   }
   return true;
@@ -563,8 +570,10 @@ KOSKI_DEFINE_SCALAR_ACCESSOR(VARCHAR);
 KOSKI_DEFINE_SCALAR_ACCESSOR(VARBINARY);
 KOSKI_DEFINE_SCALAR_ACCESSOR(DATE);
 // KOSKI_DEFINE_SCALAR_ACCESSOR(DECIMAL);
-std::shared_ptr<const Decimal128> DECIMAL() {
-  return std::make_shared<Decimal128>();
+std::shared_ptr<const DecimalType> DECIMAL(
+    const int8_t precision,
+    const int8_t scale) {
+  return std::make_shared<DecimalType>(precision, scale);
 }
 KOSKI_DEFINE_SCALAR_ACCESSOR(UNKNOWN);
 


### PR DESCRIPTION
Today function signatures do not support adding TypeSignatures that accept parameters.
Example: Decimal(10, 5), this TypeSignature is treat 10 and 5 as Velox Types or NamedTypes.

This prototype tries to add support for Signatures with constant/variable parameters so that
we can define support for Velox Operations for Decimal type.

In this change, for a signature: "DECIMAL(10,5)", the parameters 10 and 5 are still considerd as TypeSignatures
but a new enum ParameterKind is introduced to differtiante a Type from Literal.
