### PR TITLE
Fix some issues for supporting kPreceding & kFollowing in window range frame

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ endif()
 
 # set the project name
 project(velox)
+add_definitions("-DNDEBUG")
 
 list(PREPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/CMake")
 

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -451,8 +451,10 @@ inline vector_size_t Window::kRangeStartBoundSearch(
     vector_size_t leftBound,
     vector_size_t rightBound,
     const FlatVectorPtr<T>& valuesVector,
-    const vector_size_t* rawPeerStarts) {
+    const vector_size_t* rawPeerStarts,
+    vector_size_t& indexFound) {
   auto index = findIndex<T>(value, leftBound, rightBound, valuesVector, true);
+  indexFound = index;
   // Since this is a kPreceding bound it includes the row at the index.
   return rangeValuesMap_.rowIndices[rawPeerStarts[index]];
 }
@@ -465,8 +467,10 @@ vector_size_t Window::kRangeEndBoundSearch(
     vector_size_t rightBound,
     vector_size_t lastRightBoundRow,
     const FlatVectorPtr<T>& valuesVector,
-    const vector_size_t* rawPeerEnds) {
+    const vector_size_t* rawPeerEnds,
+    vector_size_t& indexFound) {
   auto index = findIndex<T>(value, leftBound, rightBound, valuesVector, false);
+  indexFound = index;
   return rangeValuesMap_.rowIndices[rawPeerEnds[index]];
 }
 
@@ -515,12 +519,15 @@ void Window::updateKRangeFrameBounds(
   }
 
   // Set the frame bounds from looking up the rangeValues index.
-  auto leftBound = 0;
-  auto rightBound = rangeValuesMap_.rowIndices.size() - 1;
+  vector_size_t leftBound = 0;
+  vector_size_t rightBound = rangeValuesMap_.rowIndices.size() - 1;
   auto lastPartitionRow = partitionStartRows_[currentPartition_ + 1] - 1;
   auto rangeIndexValues = std::dynamic_pointer_cast<FlatVector<NativeType>>(
       rangeValuesMap_.rangeValues);
+  vector_size_t indexFound;
   if (isStartBound) {
+    vector_size_t dynamicLeftBound = leftBound;
+    vector_size_t dynamicRightBound = 0;
     for (auto i = 0; i < numRows; i++) {
       // Handle null.
       // Different with duckDB result. May need to separate the handling for
@@ -530,14 +537,22 @@ void Window::updateKRangeFrameBounds(
         rawFrameBounds[i] = i;
         continue;
       }
+      // It is supposed the index being found is always on the left of the
+      // current handling position if we only consider positive lower value
+      // offset (>= 1).
+      dynamicRightBound = i;
       rawFrameBounds[i] = kRangeStartBoundSearch<NativeType>(
           rawRangeValues[i],
-          leftBound,
-          rightBound,
+          dynamicLeftBound,
+          dynamicRightBound,
           rangeIndexValues,
-          rawPeerStarts);
+          rawPeerStarts,
+          indexFound);
+      dynamicLeftBound = indexFound;
     }
   } else {
+    vector_size_t dynamicRightBound = rightBound;
+    vector_size_t dynamicLeftBound = 0;
     for (auto i = 0; i < numRows; i++) {
       // Handle null.
       // Different with duckDB result. May need to separate the handling for
@@ -547,13 +562,19 @@ void Window::updateKRangeFrameBounds(
         rawFrameBounds[i] = i;
         continue;
       }
+      // It is supposed the index being found is always on the right of the
+      // current handling position if we only consider positive higher value
+      // offset (>= 1).
+      dynamicLeftBound = i;
       rawFrameBounds[i] = kRangeEndBoundSearch<NativeType>(
           rawRangeValues[i],
-          leftBound,
-          rightBound,
+          dynamicLeftBound,
+          dynamicRightBound,
           lastPartitionRow,
           rangeIndexValues,
-          rawPeerEnds);
+          rawPeerEnds,
+          indexFound);
+      dynamicRightBound = rightBound;
     }
   }
 }

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -602,52 +602,47 @@ void Window::updateFrameBounds(
         updateKRowsFrameBounds(
             true, frameArg.value(), startRow, numRows, rawFrameBounds);
       } else {
+#define VELOX_DYNAMIC_LIMITED_SCALAR_TYPE_DISPATCH(                           \
+    TEMPLATE_FUNC, typeKind, ...)                                             \
+  [&]() {                                                                     \
+    switch (typeKind) {                                                       \
+      case ::facebook::velox::TypeKind::INTEGER: {                            \
+        return TEMPLATE_FUNC<::facebook::velox::TypeKind::INTEGER>(           \
+            __VA_ARGS__);                                                     \
+      }                                                                       \
+      case ::facebook::velox::TypeKind::TINYINT: {                            \
+        return TEMPLATE_FUNC<::facebook::velox::TypeKind::TINYINT>(           \
+            __VA_ARGS__);                                                     \
+      }                                                                       \
+      case ::facebook::velox::TypeKind::SMALLINT: {                           \
+        return TEMPLATE_FUNC<::facebook::velox::TypeKind::SMALLINT>(          \
+            __VA_ARGS__);                                                     \
+      }                                                                       \
+      case ::facebook::velox::TypeKind::BIGINT: {                             \
+        return TEMPLATE_FUNC<::facebook::velox::TypeKind::BIGINT>(            \
+            __VA_ARGS__);                                                     \
+      }                                                                       \
+      case ::facebook::velox::TypeKind::DATE: {                               \
+        return TEMPLATE_FUNC<::facebook::velox::TypeKind::DATE>(__VA_ARGS__); \
+      }                                                                       \
+      default:                                                                \
+        VELOX_FAIL(                                                           \
+            "Not supported type for sort key!: {}",                           \
+            mapTypeKindToName(typeKind));                                     \
+    }                                                                         \
+  }()
         // Sort key type.
         auto sortKeyTypePtr = outputType_->childAt(sortKeyInfo_[0].first);
-        switch (sortKeyTypePtr->kind()) {
-          case TypeKind::TINYINT:
-            updateKRangeFrameBounds<TypeKind::TINYINT>(
-                true,
-                isStartBound,
-                frameArg.value(),
-                numRows,
-                rawFrameBounds,
-                rawPeerStarts,
-                rawPeerEnds);
-            break;
-          case TypeKind::SMALLINT:
-            updateKRangeFrameBounds<TypeKind::SMALLINT>(
-                true,
-                isStartBound,
-                frameArg.value(),
-                numRows,
-                rawFrameBounds,
-                rawPeerStarts,
-                rawPeerEnds);
-            break;
-          case TypeKind::INTEGER:
-            updateKRangeFrameBounds<TypeKind::INTEGER>(
-                true,
-                isStartBound,
-                frameArg.value(),
-                numRows,
-                rawFrameBounds,
-                rawPeerStarts,
-                rawPeerEnds);
-            break;
-          case TypeKind::BIGINT:
-            updateKRangeFrameBounds<TypeKind::BIGINT>(
-                true,
-                isStartBound,
-                frameArg.value(),
-                numRows,
-                rawFrameBounds,
-                rawPeerStarts,
-                rawPeerEnds);
-            break;
-          default:
-            VELOX_USER_FAIL("Not supported type for sort key!");
-        }
+        VELOX_DYNAMIC_LIMITED_SCALAR_TYPE_DISPATCH(
+            updateKRangeFrameBounds,
+            sortKeyTypePtr->kind(),
+            true,
+            isStartBound,
+            frameArg.value(),
+            numRows,
+            rawFrameBounds,
+            rawPeerStarts,
+            rawPeerEnds);
       }
       break;
     }
@@ -658,50 +653,17 @@ void Window::updateFrameBounds(
       } else {
         // Sort key type.
         auto sortKeyTypePtr = outputType_->childAt(sortKeyInfo_[0].first);
-        switch (sortKeyTypePtr->kind()) {
-          case TypeKind::TINYINT:
-            updateKRangeFrameBounds<TypeKind::TINYINT>(
-                false,
-                isStartBound,
-                frameArg.value(),
-                numRows,
-                rawFrameBounds,
-                rawPeerStarts,
-                rawPeerEnds);
-            break;
-          case TypeKind::SMALLINT:
-            updateKRangeFrameBounds<TypeKind::SMALLINT>(
-                false,
-                isStartBound,
-                frameArg.value(),
-                numRows,
-                rawFrameBounds,
-                rawPeerStarts,
-                rawPeerEnds);
-            break;
-          case TypeKind::INTEGER:
-            updateKRangeFrameBounds<TypeKind::INTEGER>(
-                false,
-                isStartBound,
-                frameArg.value(),
-                numRows,
-                rawFrameBounds,
-                rawPeerStarts,
-                rawPeerEnds);
-            break;
-          case TypeKind::BIGINT:
-            updateKRangeFrameBounds<TypeKind::BIGINT>(
-                false,
-                isStartBound,
-                frameArg.value(),
-                numRows,
-                rawFrameBounds,
-                rawPeerStarts,
-                rawPeerEnds);
-            break;
-          default:
-            VELOX_USER_FAIL("Not supported type for sort key!");
-        }
+        VELOX_DYNAMIC_LIMITED_SCALAR_TYPE_DISPATCH(
+            updateKRangeFrameBounds,
+            sortKeyTypePtr->kind(),
+            false,
+            isStartBound,
+            frameArg.value(),
+            numRows,
+            rawFrameBounds,
+            rawPeerStarts,
+            rawPeerEnds);
+#undef VELOX_DYNAMIC_LIMITED_SCALAR_TYPE_DISPATCH
       }
       break;
     }

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -485,11 +485,6 @@ void Window::updateKRangeFrameBounds(
   auto orderByValues = BaseVector::create(sortKeyType, numRows, pool());
   windowPartition_->extractColumn(
       sortKeyInfo_[0].first, partitionOffset_, numRows, 0, orderByValues);
-  // TODO : Check if this is genuinely an error criteria.
-  VELOX_USER_CHECK_EQ(
-      orderByValues->getNullCount().value_or(0),
-      0,
-      "frame bound cannot have nulls");
   auto* rangeValuesFlatVector = orderByValues->asFlatVector<NativeType>();
   auto* rawRangeValues = rangeValuesFlatVector->mutableRawValues();
 

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -368,7 +368,7 @@ void Window::updateKRowsFrameBounds(
     // TODO: check first partition boundary and validate the frame.
     for (int i = 0; i < numRows; i++) {
       if (startValue > lastPartitionRow) {
-        rawFrameBounds[i] = lastPartitionRow;
+        rawFrameBounds[i] = lastPartitionRow + 1;
       } else {
         rawFrameBounds[i] = startValue;
       }

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -543,11 +543,21 @@ void Window::updateKRangeFrameBounds(
       rangeValuesMap_.rangeValues);
   if (isStartBound) {
     for (auto i = 0; i < numRows; i++) {
+      // Handle null.
+      if (rangeValuesFlatVector->mayHaveNulls() && rangeValuesFlatVector->isNullAt(i)) {
+        rawFrameBounds[i] = i;
+        continue;
+      }
       rawFrameBounds[i] = kRangeStartBoundSearch<NativeType>(
           rawRangeValues[i], leftBound, rightBound, rangeIndexValues, rawPeerStarts);
     }
   } else {
     for (auto i = 0; i < numRows; i++) {
+      // Handle null.
+      if (rangeValuesFlatVector->mayHaveNulls() && rangeValuesFlatVector->isNullAt(i)) {
+        rawFrameBounds[i] = i;
+        continue;
+      }
       rawFrameBounds[i] = kRangeEndBoundSearch<NativeType>(
           rawRangeValues[i],
           leftBound,

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -168,7 +168,7 @@ void Window::initRangeValuesMap() {
   };
 
   hasKRangeFrames_ = false;
-  for (const auto frame : windowFrames_) {
+  for (const auto& frame : windowFrames_) {
     if (frame.type == core::WindowNode::WindowType::kRange &&
         (isKBoundFrame(frame.startType) || isKBoundFrame(frame.endType))) {
       hasKRangeFrames_ = true;

--- a/velox/exec/Window.h
+++ b/velox/exec/Window.h
@@ -182,7 +182,8 @@ class Window : public Operator {
       vector_size_t leftBound,
       vector_size_t rightBound,
       const FlatVectorPtr<T>& valuesVector,
-      const vector_size_t* rawPeerStarts);
+      const vector_size_t* rawPeerStarts,
+      vector_size_t& indexFound);
 
   template <typename T>
   vector_size_t kRangeEndBoundSearch(
@@ -191,7 +192,8 @@ class Window : public Operator {
       vector_size_t rightBound,
       vector_size_t lastRightBoundRow,
       const FlatVectorPtr<T>& valuesVector,
-      const vector_size_t* rawPeerEnds);
+      const vector_size_t* rawPeerEnds,
+      vector_size_t& indexFound);
 
   bool finished_ = false;
   const vector_size_t numInputColumns_;

--- a/velox/exec/Window.h
+++ b/velox/exec/Window.h
@@ -156,6 +156,7 @@ class Window : public Operator {
       vector_size_t numRows,
       vector_size_t* rawFrameBounds);
 
+  template <TypeKind T>
   void updateKRangeFrameBounds(
       bool isKPreceding,
       bool isStartBound,

--- a/velox/exec/Window.h
+++ b/velox/exec/Window.h
@@ -161,7 +161,9 @@ class Window : public Operator {
       bool isStartBound,
       const FrameChannelArg& frameArg,
       vector_size_t numRows,
-      vector_size_t* rawFrameBounds);
+      vector_size_t* rawFrameBounds,
+      const vector_size_t* rawPeerStarts,
+      const vector_size_t* rawPeerEnds);
 
   // Helper function to update frame bounds.
   void updateFrameBounds(
@@ -178,7 +180,8 @@ class Window : public Operator {
       const T value,
       vector_size_t leftBound,
       vector_size_t rightBound,
-      const FlatVectorPtr<T>& valuesVector);
+      const FlatVectorPtr<T>& valuesVector,
+      const vector_size_t* rawPeerStarts);
 
   template <typename T>
   vector_size_t kRangeEndBoundSearch(
@@ -186,7 +189,8 @@ class Window : public Operator {
       vector_size_t leftBound,
       vector_size_t rightBound,
       vector_size_t lastRightBoundRow,
-      const FlatVectorPtr<T>& valuesVector);
+      const FlatVectorPtr<T>& valuesVector,
+      const vector_size_t* rawPeerEnds);
 
   bool finished_ = false;
   const vector_size_t numInputColumns_;

--- a/velox/exec/Window.h
+++ b/velox/exec/Window.h
@@ -86,6 +86,9 @@ class Window : public Operator {
       const std::shared_ptr<const core::WindowNode>& windowNode,
       const RowTypePtr& inputType);
 
+  // Helper function to initialize range values map for k Range frames.
+  void initRangeValuesMap();
+
   // Helper function to create the buffers for peer and frame
   // row indices to send in window function apply invocations.
   void createPeerAndFrameBuffers();
@@ -109,6 +112,11 @@ class Window : public Operator {
   // Helper function to call WindowFunction::resetPartition() for
   // all WindowFunctions.
   void callResetPartition(vector_size_t partitionNumber);
+
+  // For k Range frames an auxiliary structure used to look up the index
+  // of frame values is required. This function computes that structure for
+  // each partition of rows.
+  void computeRangeValuesMap();
 
   // Helper method to call WindowFunction::apply to all the rows
   // of a partition between startRow and endRow. The outputs
@@ -148,6 +156,13 @@ class Window : public Operator {
       vector_size_t numRows,
       vector_size_t* rawFrameBounds);
 
+  void updateKRangeFrameBounds(
+      bool isKPreceding,
+      bool isStartBound,
+      const FrameChannelArg& frameArg,
+      vector_size_t numRows,
+      vector_size_t* rawFrameBounds);
+
   // Helper function to update frame bounds.
   void updateFrameBounds(
       const WindowFrame& windowFrame,
@@ -157,6 +172,21 @@ class Window : public Operator {
       const vector_size_t* rawPeerStarts,
       const vector_size_t* rawPeerEnds,
       vector_size_t* rawFrameBounds);
+
+  template <typename T>
+  vector_size_t kRangeStartBoundSearch(
+      const T value,
+      vector_size_t leftBound,
+      vector_size_t rightBound,
+      const FlatVectorPtr<T>& valuesVector);
+
+  template <typename T>
+  vector_size_t kRangeEndBoundSearch(
+      const T value,
+      vector_size_t leftBound,
+      vector_size_t rightBound,
+      vector_size_t lastRightBoundRow,
+      const FlatVectorPtr<T>& valuesVector);
 
   bool finished_ = false;
   const vector_size_t numInputColumns_;
@@ -242,6 +272,27 @@ class Window : public Operator {
   // output values.
   // There is one SelectivityVector per window function.
   std::vector<SelectivityVector> validFrames_;
+
+  // When computing k Range frames, the range value for the frame index needs
+  // to be mapped to the partition row for the value.
+  // This is an auxiliary structure to materialize a mapping from
+  // range value -> row index (in RowContainer) for that purpose.
+  // It uses a vector of the ordered range values and another vector of the
+  // corresponding row indices. Ideally a binary search
+  // tree or B-tree index (especially if the data is spilled to disk) should be
+  // used.
+  struct RangeValuesMap {
+    TypePtr rangeType;
+    // The range values appear in sorted order in this vector.
+    VectorPtr rangeValues;
+    // TODO (Make this a BufferPtr so that it can be allocated in the
+    // MemoryPool) ?
+    std::vector<vector_size_t> rowIndices;
+  };
+  RangeValuesMap rangeValuesMap_;
+
+  // The above mapping is built only if required for k range frames.
+  bool hasKRangeFrames_;
 
   // Number of rows output from the WindowOperator so far. The rows
   // are output in the same order of the pointers in sortedRows. This

--- a/velox/functions/lib/window/tests/WindowTestBase.cpp
+++ b/velox/functions/lib/window/tests/WindowTestBase.cpp
@@ -119,8 +119,7 @@ void WindowTestBase::testWindowFunction(
   }
 }
 
-void WindowTestBase::testKRangeFrames(
-    const std::string& function) {
+void WindowTestBase::testKRangeFrames(const std::string& function) {
   // The current support for k Range frames is limited to ascending sort
   // orders without null values. Frames clauses generating empty frames
   // are also not supported.
@@ -153,7 +152,6 @@ void WindowTestBase::testKRangeFrames(
   };
 
   testWindowFunction({vectors}, function, {overClause}, kRangeFrames);
-
 }
 
 void WindowTestBase::assertWindowFunctionError(

--- a/velox/functions/lib/window/tests/WindowTestBase.cpp
+++ b/velox/functions/lib/window/tests/WindowTestBase.cpp
@@ -119,6 +119,43 @@ void WindowTestBase::testWindowFunction(
   }
 }
 
+void WindowTestBase::testKRangeFrames(
+    const std::string& function) {
+  // The current support for k Range frames is limited to ascending sort
+  // orders without null values. Frames clauses generating empty frames
+  // are also not supported.
+
+  // For deterministic results its expected that rows have a fixed ordering
+  // in the partition so that the range frames are predictable. So the
+  // input table.
+  vector_size_t size = 100;
+
+  auto vectors = makeRowVector({
+      makeFlatVector<int32_t>(size, [](auto row) { return row % 10; }),
+      makeFlatVector<int64_t>(size, [](auto row) { return row; }),
+      makeFlatVector<int32_t>(size, [](auto row) { return row % 7 + 1; }),
+      makeFlatVector<int64_t>(size, [](auto row) { return row % 4 + 1; }),
+  });
+
+  const std::string overClause = "partition by c0 order by c1";
+  const std::vector<std::string> kRangeFrames = {
+      "range between 5 preceding and current row",
+      "range between current row and 5 following",
+      "range between 5 preceding and 5 following",
+      "range between unbounded preceding and 5 following",
+      "range between 5 preceding and unbounded following",
+
+      "range between c3 preceding and current row",
+      "range between current row and c3 following",
+      "range between c2 preceding and c3 following",
+      "range between unbounded preceding and c3 following",
+      "range between c3 preceding and unbounded following",
+  };
+
+  testWindowFunction({vectors}, function, {overClause}, kRangeFrames);
+
+}
+
 void WindowTestBase::assertWindowFunctionError(
     const std::vector<RowVectorPtr>& input,
     const std::string& function,

--- a/velox/functions/lib/window/tests/WindowTestBase.h
+++ b/velox/functions/lib/window/tests/WindowTestBase.h
@@ -167,6 +167,8 @@ class WindowTestBase : public exec::test::OperatorTestBase {
       const std::vector<std::string>& overClauses,
       const std::vector<std::string>& frameClauses = {""});
 
+  void testKRangeFrames(const std::string& function);
+
   /// This function tests the SQL query for the window function and overClause
   /// combination with the input RowVectors. It is expected that query execution
   /// will throw an exception with the errorMessage specified.

--- a/velox/functions/prestosql/window/tests/NthValueTest.cpp
+++ b/velox/functions/prestosql/window/tests/NthValueTest.cpp
@@ -209,7 +209,7 @@ TEST_F(NthValueTest, kRangeFrames) {
   testKRangeFrames("nth_value(c2, 1)");
   testKRangeFrames("nth_value(c2, 3)");
   testKRangeFrames("nth_value(c2, 5)");
-  //testKRangeFrames("nth_value(c2, c3)");
+  // testKRangeFrames("nth_value(c2, c3)");
 }
 
 TEST_F(NthValueTest, invalidOffsets) {

--- a/velox/functions/prestosql/window/tests/NthValueTest.cpp
+++ b/velox/functions/prestosql/window/tests/NthValueTest.cpp
@@ -205,6 +205,13 @@ TEST_F(NthValueTest, nullOffsets) {
       {vectors}, "nth_value(c0, c2)", kOverClauses);
 }
 
+TEST_F(NthValueTest, kRangeFrames) {
+  testKRangeFrames("nth_value(c2, 1)");
+  testKRangeFrames("nth_value(c2, 3)");
+  testKRangeFrames("nth_value(c2, 5)");
+  //testKRangeFrames("nth_value(c2, c3)");
+}
+
 TEST_F(NthValueTest, invalidOffsets) {
   vector_size_t size = 20;
 

--- a/velox/functions/prestosql/window/tests/RankTest.cpp
+++ b/velox/functions/prestosql/window/tests/RankTest.cpp
@@ -103,6 +103,11 @@ TEST_P(RankTest, randomInput) {
   testWindowFunction({makeRandomInputVector(20), makeRandomInputVector(30)});
 }
 
+// Tests function with a randomly generated input dataset.
+TEST_P(RankTest, rangeFrames) {
+  testKRangeFrames(function_);
+}
+
 // Run above tests for all combinations of rank function and over clauses.
 VELOX_INSTANTIATE_TEST_SUITE_P(
     RankTestInstantiation,

--- a/velox/functions/prestosql/window/tests/SimpleAggregatesTest.cpp
+++ b/velox/functions/prestosql/window/tests/SimpleAggregatesTest.cpp
@@ -133,9 +133,21 @@ TEST_F(StringAggregatesTest, nonFixedWidthAggregate) {
   testWindowFunction(input, "max(c2)", kOverClauses);
 }
 
-class KPreceedingFollowingTest : public WindowTestBase {};
+class KPrecedingFollowingTest : public WindowTestBase {
+ public:
+  const std::vector<std::string> kRangeFrames = {
+      "range between unbounded preceding and 1 following",
+      "range between unbounded preceding and 2 following",
+      "range between unbounded preceding and 3 following",
+      "range between 1 preceding and unbounded following",
+      "range between 2 preceding and unbounded following",
+      "range between 3 preceding and unbounded following",
+      "range between 1 preceding and 3 following",
+      "range between 3 preceding and 1 following",
+      "range between 2 preceding and 2 following"};
+};
 
-TEST_F(KPreceedingFollowingTest, rangeFrames1) {
+TEST_F(KPrecedingFollowingTest, rangeFrames1) {
   auto vectors = makeRowVector({
       makeFlatVector<int64_t>({1, 1, 2147483650, 3, 2, 2147483650}),
       makeFlatVector<std::string>({"1", "1", "1", "2", "1", "2"}),
@@ -153,7 +165,7 @@ TEST_F(KPreceedingFollowingTest, rangeFrames1) {
   testWindowFunction({vectors}, "count(c0)", {overClause}, kRangeFrames2);
 }
 
-TEST_F(KPreceedingFollowingTest, rangeFrames2) {
+TEST_F(KPrecedingFollowingTest, rangeFrames2) {
   const std::vector<RowVectorPtr> vectors = {
       makeRowVector(
           {makeFlatVector<int64_t>({5, 6, 8, 9, 10, 2, 8, 9, 3}),
@@ -170,23 +182,12 @@ TEST_F(KPreceedingFollowingTest, rangeFrames2) {
       makeRowVector(
           {makeFlatVector<int64_t>({5, 5, 4, 6, 3, 2}),
            makeFlatVector<std::string>({"1", "2", "2", "2", "1", "2"})}),
-      // Uses int32 for sort column.
+      // Uses int32 type for sort column.
       makeRowVector(
           {makeFlatVector<int32_t>({5, 5, 4, 6, 3, 2}),
            makeFlatVector<std::string>({"1", "2", "2", "2", "1", "2"})}),
   };
-
   const std::string overClause = "partition by c1 order by c0";
-  const std::vector<std::string> kRangeFrames = {
-      "range between unbounded preceding and 1 following",
-      "range between unbounded preceding and 2 following",
-      "range between unbounded preceding and 3 following",
-      "range between 1 preceding and unbounded following",
-      "range between 2 preceding and unbounded following",
-      "range between 3 preceding and unbounded following",
-      "range between 1 preceding and 3 following",
-      "range between 3 preceding and 1 following",
-      "range between 2 preceding and 2 following"};
   for (int i = 0; i < vectors.size(); i++) {
     testWindowFunction({vectors[i]}, "avg(c0)", {overClause}, kRangeFrames);
     testWindowFunction({vectors[i]}, "sum(c0)", {overClause}, kRangeFrames);
@@ -194,12 +195,29 @@ TEST_F(KPreceedingFollowingTest, rangeFrames2) {
   }
 }
 
-TEST_F(KPreceedingFollowingTest, rowsFrames) {
+TEST_F(KPrecedingFollowingTest, rangeFrames3) {
+  const std::vector<RowVectorPtr> vectors = {
+      // Uses date type for sort column.
+      makeRowVector(
+          {makeFlatVector<Date>(
+               {Date(6), Date(1), Date(5), Date(0), Date(7), Date(1)}),
+           makeFlatVector<std::string>({"1", "2", "2", "2", "1", "2"})}),
+      makeRowVector(
+          {makeFlatVector<Date>(
+               {Date(5), Date(5), Date(4), Date(6), Date(3), Date(2)}),
+           makeFlatVector<std::string>({"1", "2", "2", "2", "1", "2"})}),
+  };
+  const std::string overClause = "partition by c1 order by c0";
+  for (int i = 0; i < vectors.size(); i++) {
+    testWindowFunction({vectors[i]}, "count(c0)", {overClause}, kRangeFrames);
+  }
+}
+
+TEST_F(KPrecedingFollowingTest, rowsFrames) {
   auto vectors = makeRowVector({
       makeFlatVector<int64_t>({1, 1, 2147483650, 3, 2, 2147483650}),
       makeFlatVector<std::string>({"1", "1", "1", "2", "1", "2"}),
   });
-
   const std::string overClause = "partition by c1 order by c0";
   const std::vector<std::string> kRangeFrames = {
       "rows between current row and 2147483647 following",

--- a/velox/functions/prestosql/window/tests/SimpleAggregatesTest.cpp
+++ b/velox/functions/prestosql/window/tests/SimpleAggregatesTest.cpp
@@ -133,5 +133,55 @@ TEST_F(StringAggregatesTest, nonFixedWidthAggregate) {
   testWindowFunction(input, "max(c2)", kOverClauses);
 }
 
+class KPreceedingFollowingTest : public WindowTestBase {};
+
+TEST_F(KPreceedingFollowingTest, rangeFrames) {
+    auto vectors = makeRowVector({
+      makeFlatVector<int64_t>({1, 1, 2147483650, 3, 2, 2147483650}),
+      makeFlatVector<std::string>({"1", "1", "1", "2", "1", "2"}),
+  });
+
+  const std::string overClause = "partition by c1 order by c0";
+  const std::vector<std::string> kRangeFrames1 = {
+      "range between current row and 2147483648 following",
+  };
+  testWindowFunction({vectors}, "count(c0)", {overClause}, kRangeFrames1);
+
+  const std::vector<std::string> kRangeFrames2 = {
+      "range between 2147483648 preceding and current row",
+  };
+  testWindowFunction({vectors}, "count(c0)", {overClause}, kRangeFrames2);
+}
+
+TEST_F(KPreceedingFollowingTest, rangeFramesFailure) {
+    auto vectors = makeRowVector({
+      makeFlatVector<int64_t>({5, 5, 4, 6, 3, 2}),
+      makeFlatVector<std::string>({"1", "2", "2", "2", "1", "2"}),
+  });
+
+  const std::string overClause = "partition by c1 order by c0";
+  const std::vector<std::string> kRangeFrames = {
+      "range between unbounded preceding and 1 following",
+  };
+  // workable.
+  // const std::vector<std::string> kRangeFrames = {
+  //     "range between current row and unbounded following",
+  // };
+  testWindowFunction({vectors}, "avg(c0)", {overClause}, kRangeFrames);
+}
+
+TEST_F(KPreceedingFollowingTest, rowsFrames) {
+    auto vectors = makeRowVector({
+      makeFlatVector<int64_t>({1, 1, 2147483650, 3, 2, 2147483650}),
+      makeFlatVector<std::string>({"1", "1", "1", "2", "1", "2"}),
+  });
+
+  const std::string overClause = "partition by c1 order by c0";
+  const std::vector<std::string> kRangeFrames = {
+      "rows between current row and 2147483647 following",
+  };
+  testWindowFunction({vectors}, "count(c0)", {overClause}, kRangeFrames);
+}
+
 }; // namespace
 }; // namespace facebook::velox::window::test

--- a/velox/functions/prestosql/window/tests/SimpleAggregatesTest.cpp
+++ b/velox/functions/prestosql/window/tests/SimpleAggregatesTest.cpp
@@ -105,6 +105,11 @@ TEST_P(SimpleAggregatesTest, randomInput) {
   testWindowFunction({makeRandomInputVector(50)});
 }
 
+// Tests function with a randomly generated input dataset.
+TEST_P(SimpleAggregatesTest, rangeFrames) {
+    testKRangeFrames(function_);
+}
+
 // Instantiate all the above tests for each combination of aggregate function
 // and over clause.
 VELOX_INSTANTIATE_TEST_SUITE_P(

--- a/velox/functions/prestosql/window/tests/SimpleAggregatesTest.cpp
+++ b/velox/functions/prestosql/window/tests/SimpleAggregatesTest.cpp
@@ -135,7 +135,7 @@ TEST_F(StringAggregatesTest, nonFixedWidthAggregate) {
 
 class KPreceedingFollowingTest : public WindowTestBase {};
 
-TEST_F(KPreceedingFollowingTest, rangeFrames) {
+TEST_F(KPreceedingFollowingTest, rangeFrames1) {
     auto vectors = makeRowVector({
       makeFlatVector<int64_t>({1, 1, 2147483650, 3, 2, 2147483650}),
       makeFlatVector<std::string>({"1", "1", "1", "2", "1", "2"}),
@@ -153,21 +153,37 @@ TEST_F(KPreceedingFollowingTest, rangeFrames) {
   testWindowFunction({vectors}, "count(c0)", {overClause}, kRangeFrames2);
 }
 
-TEST_F(KPreceedingFollowingTest, rangeFramesFailure) {
-    auto vectors = makeRowVector({
-      makeFlatVector<int64_t>({5, 5, 4, 6, 3, 2}),
-      makeFlatVector<std::string>({"1", "2", "2", "2", "1", "2"}),
-  });
+TEST_F(KPreceedingFollowingTest, rangeFrames2) {
+    const std::vector<RowVectorPtr> vectors = {
+      makeRowVector({
+      makeFlatVector<int64_t>({5, 6, 8, 9, 10, 2, 8, 9, 3}),
+      makeFlatVector<std::string>({"1", "1", "1", "1", "1", "2", "2", "2", "2"})}),
+      // Has repeated sort key.
+      makeRowVector({
+      makeFlatVector<int64_t>({5, 5, 3, 2, 8}),
+      makeFlatVector<std::string>({"1", "1", "1", "2", "1"})}),
+      makeRowVector({
+      makeFlatVector<int64_t>({5, 5, 4, 6, 3, 2, 8, 9, 9}),
+      makeFlatVector<std::string>({"1", "1", "2", "2", "1", "2", "1", "1", "2"})}),
+      };
 
   const std::string overClause = "partition by c1 order by c0";
   const std::vector<std::string> kRangeFrames = {
       "range between unbounded preceding and 1 following",
+      "range between unbounded preceding and 2 following",
+      "range between unbounded preceding and 3 following",
+      "range between 1 preceding and unbounded following",
+      "range between 2 preceding and unbounded following",
+      "range between 3 preceding and unbounded following",
+      "range between 1 preceding and 3 following",
+      "range between 3 preceding and 1 following",
+      "range between 2 preceding and 2 following"
   };
-  // workable.
-  // const std::vector<std::string> kRangeFrames = {
-  //     "range between current row and unbounded following",
-  // };
-  testWindowFunction({vectors}, "avg(c0)", {overClause}, kRangeFrames);
+  for (int i = 0; i < vectors.size(); i++) {
+    testWindowFunction({vectors[i]}, "avg(c0)", {overClause}, kRangeFrames);
+    testWindowFunction({vectors[i]}, "sum(c0)", {overClause}, kRangeFrames);
+    testWindowFunction({vectors[i]}, "count(c0)", {overClause}, kRangeFrames);
+  }
 }
 
 TEST_F(KPreceedingFollowingTest, rowsFrames) {

--- a/velox/functions/prestosql/window/tests/SimpleAggregatesTest.cpp
+++ b/velox/functions/prestosql/window/tests/SimpleAggregatesTest.cpp
@@ -107,7 +107,7 @@ TEST_P(SimpleAggregatesTest, randomInput) {
 
 // Tests function with a randomly generated input dataset.
 TEST_P(SimpleAggregatesTest, rangeFrames) {
-    testKRangeFrames(function_);
+  testKRangeFrames(function_);
 }
 
 // Instantiate all the above tests for each combination of aggregate function
@@ -136,7 +136,7 @@ TEST_F(StringAggregatesTest, nonFixedWidthAggregate) {
 class KPreceedingFollowingTest : public WindowTestBase {};
 
 TEST_F(KPreceedingFollowingTest, rangeFrames1) {
-    auto vectors = makeRowVector({
+  auto vectors = makeRowVector({
       makeFlatVector<int64_t>({1, 1, 2147483650, 3, 2, 2147483650}),
       makeFlatVector<std::string>({"1", "1", "1", "2", "1", "2"}),
   });
@@ -154,25 +154,27 @@ TEST_F(KPreceedingFollowingTest, rangeFrames1) {
 }
 
 TEST_F(KPreceedingFollowingTest, rangeFrames2) {
-    const std::vector<RowVectorPtr> vectors = {
-      makeRowVector({
-      makeFlatVector<int64_t>({5, 6, 8, 9, 10, 2, 8, 9, 3}),
-      makeFlatVector<std::string>({"1", "1", "1", "1", "1", "2", "2", "2", "2"})}),
+  const std::vector<RowVectorPtr> vectors = {
+      makeRowVector(
+          {makeFlatVector<int64_t>({5, 6, 8, 9, 10, 2, 8, 9, 3}),
+           makeFlatVector<std::string>(
+               {"1", "1", "1", "1", "1", "2", "2", "2", "2"})}),
       // Has repeated sort key.
-      makeRowVector({
-      makeFlatVector<int64_t>({5, 5, 3, 2, 8}),
-      makeFlatVector<std::string>({"1", "1", "1", "2", "1"})}),
-      makeRowVector({
-      makeFlatVector<int64_t>({5, 5, 4, 6, 3, 2, 8, 9, 9}),
-      makeFlatVector<std::string>({"1", "1", "2", "2", "1", "2", "1", "1", "2"})}),
-      makeRowVector({
-      makeFlatVector<int64_t>({5, 5, 4, 6, 3, 2}),
-      makeFlatVector<std::string>({"1", "2", "2", "2", "1", "2"})}),
+      makeRowVector(
+          {makeFlatVector<int64_t>({5, 5, 3, 2, 8}),
+           makeFlatVector<std::string>({"1", "1", "1", "2", "1"})}),
+      makeRowVector(
+          {makeFlatVector<int64_t>({5, 5, 4, 6, 3, 2, 8, 9, 9}),
+           makeFlatVector<std::string>(
+               {"1", "1", "2", "2", "1", "2", "1", "1", "2"})}),
+      makeRowVector(
+          {makeFlatVector<int64_t>({5, 5, 4, 6, 3, 2}),
+           makeFlatVector<std::string>({"1", "2", "2", "2", "1", "2"})}),
       // Uses int32 for sort column.
-      makeRowVector({
-      makeFlatVector<int32_t>({5, 5, 4, 6, 3, 2}),
-      makeFlatVector<std::string>({"1", "2", "2", "2", "1", "2"})}),
-      };
+      makeRowVector(
+          {makeFlatVector<int32_t>({5, 5, 4, 6, 3, 2}),
+           makeFlatVector<std::string>({"1", "2", "2", "2", "1", "2"})}),
+  };
 
   const std::string overClause = "partition by c1 order by c0";
   const std::vector<std::string> kRangeFrames = {
@@ -184,8 +186,7 @@ TEST_F(KPreceedingFollowingTest, rangeFrames2) {
       "range between 3 preceding and unbounded following",
       "range between 1 preceding and 3 following",
       "range between 3 preceding and 1 following",
-      "range between 2 preceding and 2 following"
-  };
+      "range between 2 preceding and 2 following"};
   for (int i = 0; i < vectors.size(); i++) {
     testWindowFunction({vectors[i]}, "avg(c0)", {overClause}, kRangeFrames);
     testWindowFunction({vectors[i]}, "sum(c0)", {overClause}, kRangeFrames);
@@ -194,7 +195,7 @@ TEST_F(KPreceedingFollowingTest, rangeFrames2) {
 }
 
 TEST_F(KPreceedingFollowingTest, rowsFrames) {
-    auto vectors = makeRowVector({
+  auto vectors = makeRowVector({
       makeFlatVector<int64_t>({1, 1, 2147483650, 3, 2, 2147483650}),
       makeFlatVector<std::string>({"1", "1", "1", "2", "1", "2"}),
   });

--- a/velox/functions/prestosql/window/tests/SimpleAggregatesTest.cpp
+++ b/velox/functions/prestosql/window/tests/SimpleAggregatesTest.cpp
@@ -165,6 +165,13 @@ TEST_F(KPreceedingFollowingTest, rangeFrames2) {
       makeRowVector({
       makeFlatVector<int64_t>({5, 5, 4, 6, 3, 2, 8, 9, 9}),
       makeFlatVector<std::string>({"1", "1", "2", "2", "1", "2", "1", "1", "2"})}),
+      makeRowVector({
+      makeFlatVector<int64_t>({5, 5, 4, 6, 3, 2}),
+      makeFlatVector<std::string>({"1", "2", "2", "2", "1", "2"})}),
+      // Uses int32 for sort column.
+      makeRowVector({
+      makeFlatVector<int32_t>({5, 5, 4, 6, 3, 2}),
+      makeFlatVector<std::string>({"1", "2", "2", "2", "1", "2"})}),
       };
 
   const std::string overClause = "partition by c1 order by c0";

--- a/velox/type/Date.h
+++ b/velox/type/Date.h
@@ -39,6 +39,10 @@ struct Date {
     days_ += days;
   }
 
+  Date operator+(const int32_t days) const {
+    return Date(days_ + days);
+  }
+
   bool operator==(const Date& other) const {
     return days_ == other.days_;
   }


### PR DESCRIPTION
Some fixes.
1. Support more types for sort key, not limited to int64.
2. Consider a common case where sort key has repeated value (viewed as peers in window range frame).
3. NULL value handling for sort key. For this case, we set the start/end index to the current row. This behavior matches spark's expectation. But I am not sure whether it is presto's expected behavior.
4. Optimize the search for bound index. I think there is no need to search the index from the whole partition. So I narrow down the search range with historical search result considered.